### PR TITLE
Collect crc errors stats

### DIFF
--- a/src/Sds011.cpp
+++ b/src/Sds011.cpp
@@ -138,15 +138,20 @@ bool Sds011::crc_ok() {
     for (int i = 2; i < 8; ++i) {
         crc += _buf[i];
     }
-    if (crc != _buf[8]) checksum_errors++;
+    if (crc != _buf[8]) ++checksum_errors;
     return crc == _buf[8];
 }
 
-bool Sds011::crc_stats(uint32_t& err, uint32_t& total){
+bool Sds011::crc_stats(uint32_t& err, uint32_t& total) {
     err = checksum_errors;
     total = processed_responses;
     return true;
 };
+
+bool Sds011::reset_crc_stats() {
+    checksum_errors = 0;
+    processed_responses = 0;
+}
 
 void Sds011::_send_cmd(enum Command cmd, const uint8_t* data, uint8_t len) {
     uint8_t i;

--- a/src/Sds011.cpp
+++ b/src/Sds011.cpp
@@ -136,8 +136,15 @@ bool Sds011::crc_ok() {
     for (int i = 2; i < 8; ++i) {
         crc += _buf[i];
     }
+    if (crc != _buf[8]) checksum_errors++;
     return crc == _buf[8];
 }
+
+bool Sds011::crc_stats(uint32_t& err, uint32_t& total){
+    err = checksum_errors;
+    total = processed_responses;
+    return true;
+};
 
 void Sds011::_send_cmd(enum Command cmd, const uint8_t* data, uint8_t len) {
     uint8_t i;
@@ -207,6 +214,8 @@ bool Sds011::_read_response(enum Command cmd) {
     }
 
     bool succ = !timeout() && _buf[9] == 0xAB;
+    if (succ) processed_responses++;
+    
     return succ;
 }
 

--- a/src/Sds011.h
+++ b/src/Sds011.h
@@ -72,6 +72,8 @@ public:
     bool timeout();
     bool crc_ok();
     bool crc_stats(uint32_t& err, uint32_t& total);
+    bool reset_crc_stats();
+
 
     bool filter_data(int n, const int* pm25_table, const int* pm10_table, int& pm25, int& pm10);
 

--- a/src/Sds011.h
+++ b/src/Sds011.h
@@ -71,6 +71,7 @@ public:
     bool query_data_auto(int& pm25, int& pm10);
     bool timeout();
     bool crc_ok();
+    bool crc_stats(uint32_t& err, uint32_t& total);
 
     bool filter_data(int n, const int* pm25_table, const int* pm10_table, int& pm25, int& pm10);
 
@@ -95,6 +96,9 @@ protected:
     bool _timeout = false;
 
     unsigned rampup_s = 10;
+
+    uint32_t checksum_errors = 0;
+    uint32_t processed_responses = 0;
 };
 
 class Sds011Async_Base : public Sds011 {


### PR DESCRIPTION
Count all messages received from SDS (both command replies and processed data packets) and checksum errors.