### PR TITLE
Fix include and dependencies

### DIFF
--- a/library.json
+++ b/library.json
@@ -23,7 +23,11 @@
     "dependencies": [
         {
             "name": "EspSoftwareSerial",
-            "version": "~8.1.0"
+            "version": "~8.2.0"
+        },
+        {
+            "name": "dok-net/ghostl",
+            "version": "^1.0.0"
         }
     ]
-}
+} 

--- a/src/esp_sds011.h
+++ b/src/esp_sds011.h
@@ -38,7 +38,7 @@ SOFTWARE.
 #endif
 
 #include <Stream.h>
-#include <circular_queue/Delegate.h>
+#include <Delegate.h>
 
 class Sds011 {
 public:


### PR DESCRIPTION
Updated the library to work with EspSoftwareSerial 8.2.0.  I've updated the `#include <circular_queue/Delegate.h>` as this was changed in the ghostl library and added the dependency